### PR TITLE
Add accelmath.h for OpenACC compilation

### DIFF
--- a/src/include/math.hpp
+++ b/src/include/math.hpp
@@ -1,6 +1,11 @@
 #pragma once
 
+#ifdef USE_ACC
+#include <accelmath.h>
+#else
 #include <cmath>
+#endif
+
 #include <cstdio>
 #include <array>
 


### PR DESCRIPTION
This PR will fix:
```
PGCC-S-1000-Call in OpenACC region to procedure 'pow' 
which has no acc routine information
```

For instance, PGI/linux86-64-llvm/19.9/include/[accelmath.h](https://www.pgroup.com/userforum/viewtopic.php?t=6060)